### PR TITLE
Usando version Python 3.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base image
-FROM python:alpine
+FROM python:3.8.0-alpine
 # Image propietary
 LABEL maintainer="Aurelio Vivas aurelio.vivas@correounivalle.edu.co"
 # Working directory inside the container


### PR DESCRIPTION
Versiones posteriores a la 3.8 de Python no permiten que se instalen las dependencias con la herramienta pip